### PR TITLE
Obtain file lock around all file write + history record

### DIFF
--- a/cgi/admin/playoffs.cgi
+++ b/cgi/admin/playoffs.cgi
@@ -31,6 +31,9 @@ if ($newSchedule){
 	$newSchedule =~ //g;
 	my $rounds = join("|", do { my %seen; grep { !$seen{$_}++ } $newSchedule =~ /^(f|sf|qf|1p|2p|3p|4p|5p)/gm});
 	$fileName = "../data/${event}.schedule.csv";
+	my $lockFile = "$fileName.lock";
+	open(my $lock, '>', $lockFile) or $webutil->error("Cannot open $lockFile", "$!\n");
+	flock($lock, LOCK_EX) or $webutil->error("Cannot lock $lockFile", "$!\n");
 	if (! -f $fileName){
 		open my $fc, ">", $fileName or $webutil->error("Cannot create $fileName", "$!\n");
 		close $fc;
@@ -54,6 +57,8 @@ if ($newSchedule){
 	print $fh $schedule;
 	close $fh;
 	$webutil->commitDataFile($fileName, "playoffs");
+	close $lock;
+	unlink($lockFile);
 }
 
 $webutil->redirect("/event.html#$event");

--- a/cgi/admin/revert.cgi
+++ b/cgi/admin/revert.cgi
@@ -6,6 +6,7 @@ use strict;
 use warnings;
 use File::Slurp;
 use CGI;
+use Fcntl qw(:flock SEEK_END);
 use lib '../../pm';
 use webutil;
 
@@ -21,10 +22,15 @@ $webutil->error("Unexpected revision") if ($revision and $revision !~ /^[0-9]+$/
 chdir "../data";
 $webutil->error("File does not exist") if ( ! -e $file);
 
+my $lockFile = "$file.lock";
+open(my $lock, '>', $lockFile) or $webutil->error("Cannot open $lockFile", "$!\n");
+flock($lock, LOCK_EX) or $webutil->error("Cannot lock $lockFile", "$!\n");
 my $content = `src cat "$revision" "$file"`;
 $webutil->error("Could not get revision content") if ( ! $content);
 $webutil->error("Error opening $file for writing", "$!") if (!open my $fh, ">", $file);
 print $fh $content;
 close $fh;
 $webutil->commitDataFile("../data/$file", "revert to revision $revision");
+close $lock;
+unlink($lockFile);
 $webutil->redirect("/revisions.html#file=$file");

--- a/cgi/scout/upload.cgi
+++ b/cgi/scout/upload.cgi
@@ -57,14 +57,16 @@ sub writeData(){
 	my ($eventCsv, $eventHeaders, $type) = @_;
 	foreach my $event (keys %{$eventCsv}){
 		my $fileName = "../data/$event.$type.csv";
+		$csvHeaders = $eventHeaders->{$event};
+
+		my $lockFile = "$fileName.lock";
+		open(my $lock, '>', $lockFile) or $webutil->error("Cannot open $lockFile", "$!\n");
+		flock($lock, LOCK_EX) or $webutil->error("Cannot lock $lockFile", "$!\n");
 		if (! -f $fileName){
 			open my $fc, ">", $fileName or $webutil->error("Cannot create $fileName", "$!\n");
 			close $fc;
 		}
-		$csvHeaders = $eventHeaders->{$event};
-
 		open my $fh, '+<', $fileName or $webutil->error("Cannot open $fileName", "$!\n");
-		flock($fh, LOCK_EX) or $webutil->error("Cannot lock $fileName", "$!\n");
 		$/ = undef;
 		my $fCsv = <$fh>;
 		$fCsv = [ map { [ split(/,/, $_, -1) ] } split(/[\r\n]+/, $fCsv) ];
@@ -98,6 +100,8 @@ sub writeData(){
 		}
 		close $fh;
 		$webutil->commitDataFile($fileName, "scouting");
+		close $lock;
+		unlink($lockFile);
 	}
 }
 


### PR DESCRIPTION
Create a lock file like `example.csv.lock` when it is modifying `example.csv` and then recording the history of that file.

Tested all files that got modified, all of them still are writing data to files.